### PR TITLE
#39 Launch scripts use Marimo (not Jupyter). Add marimo to requirements

### DIFF
--- a/launch_cims
+++ b/launch_cims
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # ARG_OPTIONAL_SINGLE([venv-name],[n],[Specify the name of the virtual environment],[cims-env])
-# ARG_OPTIONAL_BOOLEAN([jupyter],[j],[Launch Jupyter Lab],[on])
+# ARG_OPTIONAL_BOOLEAN([marimo],[m],[Launch Marimo editor],[on])
 # ARG_OPTIONAL_BOOLEAN([update],[s],[Update Python dependencies in existing virtual environment],[on])
-# ARG_HELP([This script sets up a CIMS virtual environment, installs any required dependencies, and launches a modeling notebook in Jupyter Lab.])
+# ARG_HELP([This script sets up a CIMS virtual environment, installs any required dependencies, and launches a modeling notebook in the Marimo editor.])
 # ARG_VERSION([echo setup.sh 1.0])
 # ARG_DEFAULTS_POS([])
 # ARG_DEFAULTS_POS([])
@@ -33,16 +33,16 @@ begins_with_short_option()
 
 # THE DEFAULTS INITIALIZATION - OPTIONALS
 _arg_venv_name="cims-env"
-_arg_jupyter="on"
+_arg_marimo="on"
 _arg_update="on"
 
 
 print_help()
 {
-	printf '%s\n' "This script sets up a CIMS virtual environment, installs any required dependencies, and launches a modeling notebook in Jupyter Lab."
-	printf 'Usage: %s [-n|--venv-name <arg>] [-j|--(no-)jupyter] [-s|--(no-)update] [-h|--help] [-v|--version]\n' "$0"
+	printf '%s\n' "This script sets up a CIMS virtual environment, installs any required dependencies, and launches a modeling notebook in the Marimo editor."
+	printf 'Usage: %s [-n|--venv-name <arg>] [-m|--(no-)marimo] [-s|--(no-)update] [-h|--help] [-v|--version]\n' "$0"
 	printf '\t%s\n' "-n, --venv-name: Specify the name of the virtual environment (default: 'cims-env')"
-	printf '\t%s\n' "-j, --jupyter, --no-jupyter: Launch Jupyter Lab (on by default)"
+	printf '\t%s\n' "-m, --marimo, --no-marimo: Launch Marimo editor (on by default)"
 	printf '\t%s\n' "-s, --update, --no-update: Update Python dependencies in existing virtual environment (on by default)"
 	printf '\t%s\n' "-h, --help: Prints help"
 	printf '\t%s\n' "-v, --version: Prints version"
@@ -66,16 +66,16 @@ parse_commandline()
 			-n*)
 				_arg_venv_name="${_key##-n}"
 				;;
-			-j|--no-jupyter|--jupyter)
-				_arg_jupyter="on"
-				test "${1:0:5}" = "--no-" && _arg_jupyter="off"
+			-m|--no-marimo|--marimo)
+				_arg_marimo="on"
+				test "${1:0:5}" = "--no-" && _arg_marimo="off"
 				;;
-			-j*)
-				_arg_jupyter="on"
-				_next="${_key##-j}"
+			-m*)
+				_arg_marimo="on"
+				_next="${_key##-m}"
 				if test -n "$_next" -a "$_next" != "$_key"
 				then
-					{ begins_with_short_option "$_next" && shift && set -- "-j" "-${_next}" "$@"; } || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
+					{ begins_with_short_option "$_next" && shift && set -- "-m" "-${_next}" "$@"; } || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
 				fi
 				;;
 			-s|--no-update|--update)
@@ -428,22 +428,22 @@ elif [ "$HAS_REQS" = true ]; then
     print_color "Skipping dependency installation (use --update to force).\n" "$YLW"
 fi
 
-# Step 4: Launch JupyterLab (if not disabled, now more robust)
-if [ "$_arg_jupyter" = "on" ]; then
-    if ! command -v jupyter >/dev/null 2>&1; then
-        print_color "Jupyter is not installed in this virtual environment.\n" "$RED"
-        print_color "Add 'jupyterlab' to requirements.txt and re-run with --update to install it.\n" "$YLW"
+# Step 4: Launch Marimo editor (if not disabled, now more robust)
+if [ "$_arg_marimo" = "on" ]; then
+    if ! command -v marimo >/dev/null 2>&1; then
+        print_color "Marimo is not installed in this virtual environment.\n" "$RED"
+        print_color "Add 'marimo' to requirements.txt and re-run with --update to install it.\n" "$YLW"
     else
-        NOTEBOOK="./scenarios/Reference.ipynb"
+        NOTEBOOK="./scenarios/Reference.py"
         if [ -f "$NOTEBOOK" ]; then
-            print_color "Launching JupyterLab...Use Ctrl+C to exit\n" "$NC"
-            jupyter lab --log-level=40 --notebook-dir=./ "$NOTEBOOK"
+            print_color "Launching Marimo editor...Use Ctrl+C to exit\n" "$NC"
+            marimo edit "$NOTEBOOK"
         else
-            print_color "Notebook $NOTEBOOK not found. Launching JupyterLab in repository root instead.\n" "$YLW"
-            print_color "Launching JupyterLab...Use Ctrl+C to exit\n" "$NC"
-            jupyter lab --log-level=40 --notebook-dir=./
+            print_color "Notebook $NOTEBOOK not found. Launching Marimo editor in repository root instead.\n" "$YLW"
+            print_color "Launching Marimo editor...Use Ctrl+C to exit\n" "$NC"
+            marimo edit ./
         fi
-        print_color "Closing Jupyter Lab..." "$NC"
+        print_color "Closing Marimo editor..." "$NC"
         print_color "DONE\n" "$LGRN"
     fi
 fi

--- a/launch_cims.ps1
+++ b/launch_cims.ps1
@@ -4,12 +4,12 @@
     Behaviour mirrors the Bash script:
       - Creates/uses a virtual environment
       - Installs/updates dependencies from requirements.txt
-      - Optionally launches Jupyter Lab with ./scenarios/Reference.ipynb
+      - Optionally launches Marimo editor with ./scenarios/Reference.py
 
     Usage (rough equivalents to Bash):
       ./setup.ps1
       ./setup.ps1 -VenvName myenv
-      ./setup.ps1 -NoJupyter
+      ./setup.ps1 -NoMarimo
       ./setup.ps1 -NoUpdate
       ./setup.ps1 -Help
       ./setup.ps1 -Version
@@ -20,8 +20,8 @@ param(
     [Alias('n')]
     [string]$VenvName = "cims-env",
 
-    # Equivalent to Bash --no-jupyter (default is on)
-    [switch]$NoJupyter,
+    # Equivalent to Bash --no-marimo (default is on)
+    [switch]$NoMarimo,
 
     # Equivalent to Bash --no-update (default is on)
     [switch]$NoUpdate,
@@ -33,10 +33,10 @@ param(
 # --- Help / Version ---
 
 if ($Help) {
-    Write-Host "This script sets up a CIMS virtual environment, installs any required dependencies, and launches a modeling notebook in Jupyter Lab."
-    Write-Host "Usage: setup.ps1 [-VenvName <name>] [-NoJupyter] [-NoUpdate] [-Help] [-Version]"
+    Write-Host "This script sets up a CIMS virtual environment, installs any required dependencies, and launches a modeling notebook in the Marimo editor."
+    Write-Host "Usage: setup.ps1 [-VenvName <name>] [-NoMarimo] [-NoUpdate] [-Help] [-Version]"
     Write-Host "  -VenvName   Specify the name of the virtual environment (default: 'cims-env')"
-    Write-Host "  -NoJupyter  Do not launch Jupyter Lab (on by default)"
+    Write-Host "  -NoMarimo  Do not launch Marimo editor (on by default)"
     Write-Host "  -NoUpdate   Do not update Python dependencies in existing virtual environment (on by default)"
     Write-Host "  -Help       Prints help"
     Write-Host "  -Version    Prints version"
@@ -58,8 +58,8 @@ $ErrorActionPreference = 'Stop'
 $MinPythonMajor = 3
 $MinPythonMinor = 9
 
-# Default behaviour: jupyter ON, update ON
-$LaunchJupyter = -not $NoJupyter.IsPresent
+# Default behaviour: marimo ON, update ON
+$LaunchMarimo = -not $NoMarimo.IsPresent
 $UpdateDeps    = -not $NoUpdate.IsPresent
 
 # --- Color helpers (rough analogue of print_color) ---
@@ -328,24 +328,24 @@ elseif ($hasReqs) {
     Write-Color "Skipping dependency installation (use -NoUpdate:$false to force)." Yellow
 }
 
-# --- Step 4: Launch JupyterLab (if enabled) ---
+# --- Step 4: Launch Marimo editor (if enabled) ---
 
-if ($LaunchJupyter) {
-    $jupyterPath = (Get-Command jupyter -ErrorAction SilentlyContinue)?.Source
-    if (-not $jupyterPath) {
-        Write-Color "Jupyter is not installed in this virtual environment." Red
-        Write-Color "Add 'jupyterlab' to requirements.txt and re-run with -NoUpdate:$false to install it." Yellow
+if ($LaunchMarimo) {
+    $marimoPath = (Get-Command marimo -ErrorAction SilentlyContinue)?.Source
+    if (-not $marimoPath) {
+        Write-Color "Marimo is not installed in this virtual environment." Red
+        Write-Color "Add 'marimo' to requirements.txt and re-run with -NoUpdate:$false to install it." Yellow
     } else {
-        $notebook = "./scenarios/Reference.ipynb"
+        $notebook = "./scenarios/Reference.py"
         if (Test-Path $notebook) {
-            Write-Color "Launching JupyterLab...Use Ctrl+C to exit" None
-            & jupyter lab --log-level=40 --notebook-dir=./ $notebook
+            Write-Color "Launching Marimo editor...Use Ctrl+C to exit" None
+            & marimo $notebook
         } else {
-            Write-Color "Notebook $notebook not found. Launching JupyterLab in repository root instead." Yellow
-            Write-Color "Launching JupyterLab...Use Ctrl+C to exit" None
-            & jupyter lab --log-level=40 --notebook-dir=./
+            Write-Color "Notebook $notebook not found. Launching Marimo edoter in repository root instead." Yellow
+            Write-Color "Launching Marimo editor...Use Ctrl+C to exit" None
+            & marimo ./
         }
-        Write-Color "Closing Jupyter Lab..." None
+        Write-Color "Closing Marimo editor..." None
         Write-Color "DONE" Green
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jupyter
+marimo
 cims @ git+https://github.com/EMRG-SFU/cims@staging


### PR DESCRIPTION
* requirements.txt updated to specify `marimo` instead of `jupyter`.
* launch_cims scripts updated to launch `marimo edit *` instead of `jupyter lab`. Command line argument parsing updated by hand to accomodate change.

I can't easily test the ps1 script on a windows machine, but the `launch_cims` script is tested and working properly on my macbook.